### PR TITLE
TextureD3D11::save() did not take fixSeams argument into account

### DIFF
--- a/rendererD3D11/CtrTextureD3D11.cpp
+++ b/rendererD3D11/CtrTextureD3D11.cpp
@@ -644,7 +644,7 @@ TextureD3D11::save(const std::string& filePathName,
             }
         }
 
-        if (this->isCubeMap())
+        if (this->isCubeMap() && fixSeams)
         {
             if (parameters->format() == Ctr::PF_A8R8G8B8)
             {


### PR DESCRIPTION
Tiny fix that is needed to fix an upcoming PR for IBLBaker.

I noticed that at higher mip levels (higher roughness) ugly seams were introduced (the edges of the generated cubemaps  being too bright). I found that strange since other tools like LYS and Unreal didn't have these seems. Then I found out that IBLBaker passes `true` to the `fixSeams` parameter, something that is not needed for modern graphics APIs since cubemaps are correctly sampled at their edges. But it turned out this parameter was being ignored when saving the images, the old AMD code to average the edges was always applied.


